### PR TITLE
Clarify docker-compose usage and fix Coinbase orderbook link

### DIFF
--- a/FOLLOW-UP.md
+++ b/FOLLOW-UP.md
@@ -2,11 +2,7 @@
 
 ### Q) What libraries did you add to the frontend? What are they used for?
 
-### Q) What's the command to start the frontend application locally?
-
 ### Q) What libraries did you add to the backend? What are they used for?
-
-### Q) What's the command to start the backend application locally?
 
 ### Q) Any other comments we should read before evaluating your solution?
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ NOTE: Please make the server listen on port `:4000`.
 
 - **[Crypto Trading 101: How to Read an Exchange Order Book](https://www.coindesk.com/crypto-trading-101-how-to-read-an-exchange-order-book)**
 - **[Binance Order Book API Endpoint](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#order-book)**
-- **[Coinbase Order Book API Endpoint](https://docs.cloud.coinbase.com/exchange/reference/exchangerestapi_getproductbook)**
+- **[Coinbase Order Book API Endpoint](https://docs.cloud.coinbase.com/exchange/reference/exchangerestapi_getproductbook-1)**
 
 _Note that both APIs above are public and don't require any authentication._
 
@@ -98,9 +98,7 @@ Docker image and creates two containers - one for backend and one for frontend.
 
 The respective folder is mounted in `/app` directory inside the container.
 
-It isn't a requirement to use it, but may be convenient.
-
-NOTE: We WILL run your code inside these containers.
+We WILL run your code inside these containers so please make sure your apps load correctly in this setup.
 
 ## Submitting Your Code
 


### PR DESCRIPTION
Clarify that the docker-compose setup is mandatory. Also removing the follow-up section where we ask how the app is started. This is redundant as we mandate the way to start the apps.

Also, Coinbase updated their orderbook API endpoint documentation URL, this fixes it.