### PR TITLE
Fix Coinbase docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ NOTE: Please make the server listen on port `:4000`.
 
 - **[Crypto Trading 101: How to Read an Exchange Order Book](https://www.coindesk.com/crypto-trading-101-how-to-read-an-exchange-order-book)**
 - **[Binance Order Book API Endpoint](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#order-book)**
-- **[Coinbase Order Book API Endpoint](https://docs.cloud.coinbase.com/exchange/reference/exchangerestapi_getproductbook-1)**
+- **[Coinbase Order Book API Endpoint](https://docs.cloud.coinbase.com/exchange/reference/exchangerestapi_getproductbook)**
 
 _Note that both APIs above are public and don't require any authentication._
 


### PR DESCRIPTION
They keep on changing their doc URL without redirects to fall back on!